### PR TITLE
Add support for HP Omen 16-wf0000n1

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A low-level utility for manual fan speed control on the `HP OMEN 16 Gaming Lapto
 | Omen 16-ap0097ax         | `8E35`       | @locomotiivo        |
 | Omen Transcend 14-fb0xxx | `8C58`       | @DistortedDragon1o4 |
 | HP Omen 15-en1xxx        | `88D2`       | @GosnatIron         |
+| HP Omen 16-wf0000n1      | `8BAC`       | @SlopeSlayer910     |
 
 >  NOTE: If your board is not listed above and you want support to be added, feel free to open an issue.
 

--- a/driver/pankha.c
+++ b/driver/pankha.c
@@ -123,6 +123,14 @@ const struct dmi_system_id pankha_whitelist[] = {
             },
         .driver_data = (void *)&type2_ec,
     },
+    {
+        .ident = "HP Omen 16-wf0000n1",
+        .matches =
+            {
+                DMI_MATCH(DMI_BOARD_NAME, "8BAC"),
+            },
+        .driver_data = (void *)&type1_ec,
+    },
     {}};
 
 /* Helper function declarations */


### PR DESCRIPTION
This PR adds support for HP Omen 16-wf0000n1 (board id 8BAC) by adding its DMI_BOARD_NAME to the pankha_whitelist.

Merely adding to the whitelist works because the underlying EC register mappings remain the same as type 1 boards.

Closes: #11 